### PR TITLE
Fix newsletter user registration

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -11,7 +11,9 @@ interface ImportMetaEnv {
    readonly FIREBASE_AUTH_CERT_URL: string
    readonly FIREBASE_CLIENT_CERT_URL: string;
    readonly FIREBASE_SERVICE_ACCOUNT_KEY: string;
-   readonly MAILERLITE_API: string;}
+   readonly MAILERLITE_API: string;
+   readonly MAILERLITE_CONNECT_API_KEY: string;
+}
 
 interface ImportMeta {
    readonly env: ImportMetaEnv;


### PR DESCRIPTION
## Summary
- switch user signup route to use MailerLite connect API
- document `MAILERLITE_CONNECT_API_KEY` in environment typings

## Testing
- `npm run format` *(fails: Cannot find module 'prettier-config-standard')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6847e8fe316c83309786dfca82f6099a