### PR TITLE
Handle email query param in createUser endpoint

### DIFF
--- a/src/pages/api/auth/createUser.ts
+++ b/src/pages/api/auth/createUser.ts
@@ -54,12 +54,17 @@ export const GET: APIRoute = async ({ request }) => {
 	const db = getFirestore()
 	const usersRef = db.collection('users')
 
-	const email = request.headers.get('Authorization')
+        let email = request.headers.get('Authorization')
 
-	if (!email) {
-		console.error('❌ No email provided in Authorization header')
-		return new Response('No email provided', { status: 400 })
-	}
+        if (!email) {
+                const url = new URL(request.url)
+                email = url.searchParams.get('email') || undefined
+        }
+
+        if (!email) {
+                console.error('❌ No email provided')
+                return new Response('No email provided', { status: 400 })
+        }
 
 	try {
 		const querySnapshot = await getUserFromFirestore(email)


### PR DESCRIPTION
## Summary
- support both header and query parameter for `email` in `createUser` API

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format:check` *(fails: Prettier config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848107ca6848330ab3876ea0db2560d